### PR TITLE
Prevent dealing beyond remaining cards

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -27,8 +27,11 @@ func newDeck() deck {
 }
 
 func (d deck) deal(handSize int) (deck, deck) {
-	var hand deck
-	for i := handSize; i > 0; i-- {
+	if handSize > len(d) {
+		handSize = len(d)
+	}
+	hand := make(deck, 0, handSize)
+	for i := 0; i < handSize; i++ {
 		hand = append(hand, d[0]) // one from the top
 		d = d[1:]
 	}
@@ -37,9 +40,9 @@ func (d deck) deal(handSize int) (deck, deck) {
 
 func (d deck) toStringSlice() []string {
 	s := make([]string, len(d))
-    for i := range d {
-        s[i] = d[i].value + d[i].suit
-    }
+	for i := range d {
+		s[i] = d[i].value + d[i].suit
+	}
 	return s
 }
 

--- a/deck_test.go
+++ b/deck_test.go
@@ -1,0 +1,25 @@
+package main
+
+import "testing"
+
+func TestDealDoesNotExceedDeck(t *testing.T) {
+	d := newDeck()
+	remainder, hand := d.deal(60)
+	if len(hand) != 52 {
+		t.Errorf("expected hand size 52, got %d", len(hand))
+	}
+	if len(remainder) != 0 {
+		t.Errorf("expected remainder 0, got %d", len(remainder))
+	}
+}
+
+func TestDealReducesDeck(t *testing.T) {
+	d := newDeck()
+	remainder, hand := d.deal(5)
+	if len(hand) != 5 {
+		t.Errorf("expected hand size 5, got %d", len(hand))
+	}
+	if len(remainder) != 52-5 {
+		t.Errorf("expected remainder %d, got %d", 52-5, len(remainder))
+	}
+}


### PR DESCRIPTION
## Summary
- Guard against dealing more cards than exist in deck
- Add regression tests for deal behavior

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_e_6894d7d221b48332ab74c6bb74cb8fa5