### PR TITLE
Modify deal to mutate deck

### DIFF
--- a/deck.go
+++ b/deck.go
@@ -26,16 +26,16 @@ func newDeck() deck {
 	return cards
 }
 
-func (d deck) deal(handSize int) (deck, deck) {
-	if handSize > len(d) {
-		handSize = len(d)
+func (d *deck) deal(handSize int) deck {
+	if handSize > len(*d) {
+		handSize = len(*d)
 	}
 	hand := make(deck, 0, handSize)
 	for i := 0; i < handSize; i++ {
-		hand = append(hand, d[0]) // one from the top
-		d = d[1:]
+		hand = append(hand, (*d)[0]) // one from the top
+		*d = (*d)[1:]
 	}
-	return d, hand
+	return hand
 }
 
 func (d deck) toStringSlice() []string {

--- a/deck_test.go
+++ b/deck_test.go
@@ -4,22 +4,22 @@ import "testing"
 
 func TestDealDoesNotExceedDeck(t *testing.T) {
 	d := newDeck()
-	remainder, hand := d.deal(60)
+	hand := d.deal(60)
 	if len(hand) != 52 {
 		t.Errorf("expected hand size 52, got %d", len(hand))
 	}
-	if len(remainder) != 0 {
-		t.Errorf("expected remainder 0, got %d", len(remainder))
+	if len(d) != 0 {
+		t.Errorf("expected remainder 0, got %d", len(d))
 	}
 }
 
 func TestDealReducesDeck(t *testing.T) {
 	d := newDeck()
-	remainder, hand := d.deal(5)
+	hand := d.deal(5)
 	if len(hand) != 5 {
 		t.Errorf("expected hand size 5, got %d", len(hand))
 	}
-	if len(remainder) != 52-5 {
-		t.Errorf("expected remainder %d, got %d", 52-5, len(remainder))
+	if len(d) != 52-5 {
+		t.Errorf("expected remainder %d, got %d", 52-5, len(d))
 	}
 }

--- a/game.go
+++ b/game.go
@@ -52,10 +52,9 @@ func NewGame() *Game {
 }
 
 func (g *Game) deal() {
-	var h deck
-	g.deck, h = g.deck.deal(2)
+	h := g.deck.deal(2)
 	g.players[0].Hand = h
-	g.deck, h = g.deck.deal(2)
+	h = g.deck.deal(2)
 	g.players[1].Hand = h
 	g.players[0].Chips -= smallBlind
 	g.players[1].Chips -= bigBlind
@@ -65,12 +64,10 @@ func (g *Game) deal() {
 func (g *Game) nextStage() {
 	switch g.stage {
 	case 0:
-		var h deck
-		g.deck, h = g.deck.deal(3)
+		h := g.deck.deal(3)
 		g.board = append(g.board, h...)
 	case 1, 2:
-		var h deck
-		g.deck, h = g.deck.deal(1)
+		h := g.deck.deal(1)
 		g.board = append(g.board, h...)
 	case 3:
 		winner := g.winner()


### PR DESCRIPTION
## Summary
- Change `deck.deal` to operate on a pointer and return only the hand
- Update game logic to use the in-place deck mutation
- Adjust tests to verify the deck shrinks after dealing

## Testing
- `go vet ./...`
- `go test ./...`
- `go run . & pid=$!; sleep 1; curl -I localhost:8080; kill $pid`

------
https://chatgpt.com/codex/tasks/task_e_6895044893b88332b8e1aeb125cbff76