### PR TITLE
Add animated Dali background and chip celebration

### DIFF
--- a/assets/dali_table.svg
+++ b/assets/dali_table.svg
@@ -1,0 +1,10 @@
+<svg width="1920" height="1080" xmlns="http://www.w3.org/2000/svg">
+  <rect width="1920" height="1080" fill="#2e1f17"/>
+  <ellipse cx="960" cy="760" rx="800" ry="200" fill="#35654d"/>
+  <rect x="160" y="600" width="1600" height="200" fill="#7b5e2a" stroke="#000" stroke-width="5"/>
+  <circle cx="960" cy="300" r="150" fill="#f5d6b4"/>
+  <path d="M900 250 q60 -40 120 0" stroke="#000" stroke-width="5" fill="none"/>
+  <path d="M900 250 q60 40 120 0" stroke="#000" stroke-width="5" fill="none"/>
+  <path d="M840 330 q40 -20 80 0" stroke="#000" stroke-width="5" fill="none"/>
+  <path d="M1000 330 q40 20 80 0" stroke="#000" stroke-width="5" fill="none"/>
+</svg>

--- a/game.go
+++ b/game.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"fmt"
 	"math/rand"
 	"time"
 )
@@ -34,6 +35,7 @@ type State struct {
 	PlayerHand  []string `json:"playerHand"`
 	NPCHand     []string `json:"npcHand"`
 	Message     string   `json:"message"`
+	Winner      string   `json:"winner"`
 }
 
 func NewGame() *Game {
@@ -118,7 +120,7 @@ func (g *Game) PlayerFold() string {
 	g.players[0].InHand = false
 	g.players[1].Chips += g.pot
 	g.stage = 4
-	return "You folded."
+	return "You folded. Dali NPC wins the pot!"
 }
 
 func (g *Game) PlayerCall() string {
@@ -141,13 +143,19 @@ func (g *Game) NPCAct() string {
 	if g.stage < 4 {
 		g.nextStage()
 	}
+	if g.stage == 4 {
+		w := g.players[g.winner()].Name
+		return fmt.Sprintf("%s wins the pot!", w)
+	}
 	return quips[rand.Intn(len(quips))]
 }
 
 func (g *Game) State(revealNPC bool, msg string) State {
 	npcHand := []string{}
+	winner := ""
 	if revealNPC {
 		npcHand = g.players[1].Hand.toStringSlice()
+		winner = g.players[g.winner()].Name
 	}
 	return State{
 		PlayerChips: g.players[0].Chips,
@@ -157,6 +165,7 @@ func (g *Game) State(revealNPC bool, msg string) State {
 		PlayerHand:  g.players[0].Hand.toStringSlice(),
 		NPCHand:     npcHand,
 		Message:     msg,
+		Winner:      winner,
 	}
 }
 

--- a/templates/game.gohtml
+++ b/templates/game.gohtml
@@ -5,7 +5,7 @@
     <title>Dali Hold'em</title>
     <style>
         body {
-            background-image: url('https://upload.wikimedia.org/wikipedia/en/d/dd/The_Persistence_of_Memory.jpg');
+            background-image: url('/res/dali_table.svg');
             background-size: cover;
             font-family: sans-serif;
             color: #fff;
@@ -17,8 +17,28 @@
             width: 800px;
             border-radius: 20px;
             text-align: center;
+            position: relative;
+            overflow: hidden;
         }
-        img.card { width: 80px; }
+        img.card {
+            width: 100px;
+            border: 2px solid #fff;
+            border-radius: 5px;
+            box-shadow: 0 0 10px #fff;
+            animation: deal 0.5s ease-out;
+        }
+        @keyframes deal {
+            from { transform: translateY(-50px); opacity: 0; }
+            to { transform: translateY(0); opacity: 1; }
+        }
+        .chip {
+            width: 20px;
+            height: 20px;
+            background: radial-gradient(circle, #f00 0%, #900 100%);
+            border-radius: 50%;
+            position: absolute;
+            pointer-events: none;
+        }
     </style>
 </head>
 <body>
@@ -54,6 +74,9 @@ ws.onmessage = function(evt) {
     document.getElementById('board').innerHTML = s.board.map(renderCard).join('');
     document.getElementById('player-hand').innerHTML = s.playerHand.map(renderCard).join('');
     document.getElementById('npc-hand').innerHTML = s.npcHand.map(renderCard).join('');
+    if (s.winner) {
+        celebrate(s.winner);
+    }
 };
 ws.onerror = function() {
     document.getElementById('message').innerText = 'WebSocket error';
@@ -66,6 +89,25 @@ function renderCard(c) {
 }
 function sendAction(a) {
     ws.send(JSON.stringify({action:a}));
+}
+
+function celebrate(winner) {
+    var table = document.getElementById('table');
+    var potEl = document.getElementById('pot');
+    var destEl = winner === 'You' ? document.getElementById('player-chips') : document.getElementById('npc-chips');
+    var tableRect = table.getBoundingClientRect();
+    var potRect = potEl.getBoundingClientRect();
+    var destRect = destEl.getBoundingClientRect();
+    var chip = document.createElement('div');
+    chip.className = 'chip';
+    chip.style.left = (potRect.left - tableRect.left) + 'px';
+    chip.style.top = (potRect.top - tableRect.top) + 'px';
+    table.appendChild(chip);
+    chip.animate([
+        { left: chip.style.left, top: chip.style.top },
+        { left: (destRect.left - tableRect.left) + 'px', top: (destRect.top - tableRect.top) + 'px' }
+    ], { duration: 1000, fill: 'forwards' });
+    setTimeout(function(){ chip.remove(); }, 1000);
 }
 </script>
 </body>


### PR DESCRIPTION
## Summary
- Replace remote background with local high-resolution Dali-style table image
- Animate cards and chips with winner celebration
- Track hand winner in game state for chip movement and messaging

## Testing
- `go test -v ./...`


------
https://chatgpt.com/codex/tasks/task_e_6895107a7b9c83329565eb5441b99ca9